### PR TITLE
Feature/0028 delete past screenings task

### DIFF
--- a/src/app/Console/Commands/DeletePastScreenings.php
+++ b/src/app/Console/Commands/DeletePastScreenings.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Screening;
+use Carbon\Carbon;
+
+class DeletePastScreenings extends Command
+{
+    /**
+     * コンソールコマンドの名前と使い方
+     *
+     * @var string
+     */
+    protected $signature = 'screenings:delete-past';
+
+    /**
+     * コンソールコマンドの説明
+     *
+     * @var string
+     */
+    protected $description = '過去の上映スケジュールを削除する';
+
+    /**
+     * consoleコマンドの実行
+     */
+    public function handle()
+    {
+        $oneWeekAgo = Carbon::now()->subWeek();
+        $count = Screening::where('end_time', '<', $oneWeekAgo)->delete();
+
+        // コンソールに出力
+        $this->info("{$count} 件の上映スケジュール（1週間以上前）を削除しました。");
+
+        return Command::SUCCESS; // 終了ステータスコードを返す
+    }
+}

--- a/src/database/seeders/DeploymentSeeder.php
+++ b/src/database/seeders/DeploymentSeeder.php
@@ -57,6 +57,12 @@ class DeploymentSeeder extends Seeder
                 'genre' => 99,
             ]);
 
+            $movie6 = Movie::factory()->create([
+                'title' => 'ターミネーター2',
+                'description' => '最初のターミネーター出現から10年後。サラ・コナーの息子ジョンは少年に成長。ジョンは、近未来に人類抵抗軍のリーダーだ。機械軍はジョンを少年のうちに殺すため、新しいターミネーターを送り込む。ある日ロサンゼルスに2体のターミネーターが未来から送り込まれる。息子を守るために、サラの死闘が始まる。だが、残忍非道なターミネーターに立ち向かうサラとジョン母子に、強い味方が現れる。いかなる犠牲を払ってもジョンを守れと厳命を受け、人類抵抗軍によって送り込まれた戦士だ。未来への戦いが、いま始まる……',
+                'genre' => 99,
+            ]);
+
             $now = \Carbon\Carbon::now();
 
             $tommorow = $now->copy()->addDays(1);
@@ -94,9 +100,16 @@ class DeploymentSeeder extends Seeder
                 'end_time' => $daysLater20->copy()->setTime(11, 0, 0),
             ]);
 
+            $daysAgo = $now->copy()->subDays(15);
+            $screening6 = Screening::factory()->create([
+                'movie_id' => $movie6->id,
+                'start_time' => $daysAgo->copy()->setTime(9, 0, 0),
+                'end_time' => $daysAgo->copy()->setTime(11, 0, 0),
+            ]);
+
             $rows = ['A', 'B']; // 行
             $seatsPerRow = 10;       // 1行あたりの席数
-            $screening_ids = [$screening1->id, $screening2->id, $screening3->id, $screening4->id, $screening5->id];
+            $screening_ids = [$screening1->id, $screening2->id, $screening3->id, $screening4->id, $screening5->id, $screening6->id];
 
             foreach ($screening_ids as $screening_id) {
                 $seats = [];

--- a/src/database/seeders/SampleDataSeeder.php
+++ b/src/database/seeders/SampleDataSeeder.php
@@ -111,5 +111,35 @@ class SampleDataSeeder extends Seeder
         $seatSample3->user_id = $user->id;
         $seatSample3->is_reserved = false;
         $seatSample3->save();
+
+        $movie = Movie::factory()->create([
+            'title' => 'プロジェクトA',
+            'description' => 'ジャッキー・チェン主演のアクション映画。20世紀初頭の香港。海賊の撃退をドラゴンたち水上警察が任せられるもうまくいかない。おかげでライバルがいる陸上警察に吸収。しかし友情が芽生え、協力して海賊退治へ乗り出す。',
+            'genre' => 2,
+        ]);
+
+        $before15Days = Carbon::now()->subDays(15);
+
+        $screening = Screening::factory()->create([
+            'movie_id' => $movie->id,
+            'start_time' => $before15Days->clone()->setTime(10, 0, 0),
+            'end_time' => $before15Days->clone()->setTime(12, 0, 0),
+        ]);
+
+        foreach (range('A', 'B') as $row) {
+            foreach (range(1, 10) as $number) {
+                $seat = Seat::factory()->create([
+                    'screening_id' => $screening->id,
+                    'user_id' => NULL,
+                    'row' => $row,
+                    'number' => $number,
+                    'is_reserved' => false,
+                ]);
+            }
+        }
+        $seatSample4 = Seat::where('screening_id', $screening->id)->where('row', 'B')->where('number', 5)->first();
+        $seatSample4->user_id = $user->id;
+        $seatSample4->is_reserved = false;
+        $seatSample4->save();
     }
 }

--- a/src/routes/console.php
+++ b/src/routes/console.php
@@ -2,7 +2,11 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use App\Console\Commands\DeletePastScreenings;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
+
+Schedule::command('screenings:delete-past')->dailyAt('03:00');

--- a/src/tests/Feature/DeletePastScreeningsCommandTest.php
+++ b/src/tests/Feature/DeletePastScreeningsCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\Screening;
+use App\Models\Movie;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Artisan;
+
+class DeletePastScreeningsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 1週間以上前の上映スケジュールを削除するコマンドのテスト
+     */
+    public function test_deletes_screenings_ended_more_than_one_week_ago(): void
+    {
+        $movie = Movie::factory()->create();
+
+        // 削除対象と非対象を作成
+        $screening1 = Screening::factory()->create([
+            'start_time' => Carbon::now()->subDays(8)->setTime(10, 0, 0),
+            'end_time' => Carbon::now()->subDays(8)->setTime(12, 0, 0),
+        ]);
+
+        $screening2 = Screening::factory()->create([
+            'start_time' => Carbon::now()->subDays(3)->setTime(14, 0, 0),
+            'end_time' => Carbon::now()->subDays(3)->setTime(16, 0, 0),
+        ]);
+
+        $this->assertDatabaseCount('screenings', 2);
+
+        Artisan::call('screenings:delete-past'); // Artisanコマンドを実行
+
+        $this->assertDatabaseCount('screenings', 1);
+
+        // 非対象のレコードが残ってるかどうかを確認
+        $this->assertDatabaseHas('screenings', [
+            'id' => $screening2->id,
+        ]);
+    }
+}


### PR DESCRIPTION
### 概要
過去1週間前日付の上映スケジュールをタスクスケジュールによって自動削除される実装

### 実施内容
- 該当のScreenモデルを削除するphp artisanコマンド、`screenings:delete-past`コマンドを実装
- src/routes/console.phpに作成したコマンドを登録
- テストコードも実装。DeletePastScreeningsCommandTest
- 今回の実装に合わせSeederファイルも一部修正・追記

### 備考
